### PR TITLE
Session and session storage services. Main layout, basic header

### DIFF
--- a/src/src/app/app-routing.module.ts
+++ b/src/src/app/app-routing.module.ts
@@ -1,11 +1,20 @@
+import { componentFactoryName } from '@angular/compiler';
 import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
+import { HomeComponent } from './components/home/home.component';
+import { LayoutComponent } from './components/layout/layout.component';
 import { LoginComponent } from './components/login/login.component';
 
 
 const routes: Routes = [
   { path: '', redirectTo: '/login', pathMatch: 'full'},
-  { path: 'login', component: LoginComponent }, // login component
+
+  { path: '', component: LayoutComponent, children: [
+    { path: 'home', component: HomeComponent }
+  ]
+  },
+
+  { path: 'login', component: LoginComponent }, 
 ];
 
 @NgModule({

--- a/src/src/app/app.module.ts
+++ b/src/src/app/app.module.ts
@@ -12,6 +12,9 @@ import { LoginComponent } from './components/login/login.component';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import {MatFormFieldModule} from '@angular/material/form-field';
+import {MatInputModule} from '@angular/material/input';
+import {MatButtonModule} from '@angular/material/button';
 
 @NgModule({
   declarations: [
@@ -29,7 +32,10 @@ import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
     ReactiveFormsModule,
     FormsModule,
     BrowserAnimationsModule,
-    MatProgressSpinnerModule
+    MatProgressSpinnerModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule
   ],
   providers: [],
   bootstrap: [AppComponent]

--- a/src/src/app/components/header/header/header.component.html
+++ b/src/src/app/components/header/header/header.component.html
@@ -1,25 +1,20 @@
-<nav class="navbar navbar-default">
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark">
     <div class="container-fluid">
-        <div class="navbar-header">
-            <a href="#" class="navbar-brand">CAEBO</a>
+      <a class="navbar-brand" href="/home">CAEBO</a>
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="navbarSupportedContent">
+        <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+          <li class="nav-item">
+            <a class="nav-link active" aria-current="page" routerLink="/home">Home</a>
+          </li>
+        </ul>
+        <div class="p-2">
+            <button mat-raised-button color="accent" type="submit" (click)="logout()">
+                <span>Logout</span>
+            </button>
         </div>
-
-        <div class='navbar-default'>
-            <ul class="nav navbar-nav">
-                <li routerLinkActive="active"><a routerLink="/home">About</a></li>
-                <li routerLinkActive="active"><a routerLink="/home/companies">Companies</a></li>
-            </ul>
-            <ul class="nav navbar-nav navbar-right">
-                <li 
-                class="dropdown"
-                appDropdown>
-                    <a class="dropdown-toggle" style="cursor: pointer;" role="button">Manage  <span class="caret"></span></a>
-                    <ul class="dropdown-menu">
-                        <li><a style="cursor: pointer;">Save Data</a></li>
-                        <li><a style="cursor: pointer;">Fetch Data</a></li>
-                    </ul>
-                </li>
-            </ul>
-        </div>
+      </div>
     </div>
-</nav>
+  </nav>

--- a/src/src/app/components/header/header/header.component.ts
+++ b/src/src/app/components/header/header/header.component.ts
@@ -1,4 +1,6 @@
 import { Component, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
+import { SessionService } from 'src/app/services/auth/session.service';
 
 @Component({
   selector: 'app-header',
@@ -7,9 +9,17 @@ import { Component, OnInit } from '@angular/core';
 })
 export class HeaderComponent implements OnInit {
 
-  constructor() { }
+  constructor(
+    private session: SessionService,
+    private router: Router
+  ) { }
 
   ngOnInit(): void {
+  }
+
+  logout() {
+    this.session.logout();
+    this.router.navigate(['login']);
   }
 
 }

--- a/src/src/app/components/home/home.component.css
+++ b/src/src/app/components/home/home.component.css
@@ -1,0 +1,7 @@
+.group-admin-text {
+    font-size: 1.5rem;
+}
+
+.group-admin-text-color {
+    color: #d49100;
+}

--- a/src/src/app/components/home/home.component.html
+++ b/src/src/app/components/home/home.component.html
@@ -1,9 +1,28 @@
-<div *ngFor="let user of users">
-    <div class="card">
-        <div class="card-body">
-            <h1 style="cursor: pointer;" (click)="log(user.last_name)">{{ user.first_name }}</h1>
-            <p>{{ user.last_name }}</p>
-            <button type="btn btn-danger" (click)="log(user.first_name)">Change Name</button>
+<div class="container">
+    <div class="d-flex justify-content-center align-items-center">
+        <div class="p-2">
+            <h1>Home</h1>
+        </div>
+        <!-- <div class="p-2">
+            <button mat-raised-button color="primary" type="submit" (click)="logout()">
+                <span>Logout</span>
+            </button>
+        </div> -->
+    </div>
+    <div *ngIf="userSession.user && !submitting" class="d-flex justify-content-center p-4">
+        <div class="card shadow w-50 d-flex align-items-center">
+                <div class="p-2">
+                    <h3>{{ userSession.user.lastName }}, {{ userSession.user.firstName }}</h3>
+                </div>
+                <div *ngIf="!userGroupAdmin" class="p-2">
+                    <h4><em>{{ userSession.user.groupName }}</em></h4>
+                </div>
+                <div *ngIf="userGroupAdmin" class="p-2">
+                    <span class="group-admin-text"><em>{{ userSession.user.groupName }} - </em><span class="group-admin-text group-admin-text-color">Admin</span></span>
+                </div>
+                <div class="p-2">
+                    <span>"{{ userSession.user.username }}"</span>
+                </div>
         </div>
     </div>
 </div>

--- a/src/src/app/components/home/home.component.html
+++ b/src/src/app/components/home/home.component.html
@@ -3,11 +3,6 @@
         <div class="p-2">
             <h1>Home</h1>
         </div>
-        <!-- <div class="p-2">
-            <button mat-raised-button color="primary" type="submit" (click)="logout()">
-                <span>Logout</span>
-            </button>
-        </div> -->
     </div>
     <div *ngIf="userSession.user && !submitting" class="d-flex justify-content-center p-4">
         <div class="card shadow w-50 d-flex align-items-center">

--- a/src/src/app/components/home/home.component.ts
+++ b/src/src/app/components/home/home.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
 import { Subscription } from 'rxjs';
-import { ApiResponse, User } from 'src/app/models/caebo.constants';
-import { UserService } from 'src/app/services/user/user.service';
+import { SessionService } from 'src/app/services/auth/session.service';
 
 
 @Component({
@@ -9,29 +9,20 @@ import { UserService } from 'src/app/services/user/user.service';
   templateUrl: './home.component.html',
   styleUrls: ['./home.component.css']
 })
-export class HomeComponent implements OnInit, OnDestroy {
-  users: User[];
+export class HomeComponent implements OnInit {
+  userSession;
+  userGroupAdmin: boolean;
+  submitting: boolean;
   userSubscription: Subscription;
+  name: string;
 
-  constructor(private service: UserService) { }
+  constructor(
+    private session: SessionService
+    ) { }
 
   ngOnInit(): void {
-    this.userSubscription = this.service.getUsers().subscribe(
-      (data) => {
-        this.users = data.message;
-      },
-      (error) => {
-        console.log(error);
-      },
-      () => {  }
-    );
+    this.userSession = this.session.getSessionValue();
+    this.userGroupAdmin = this.userSession.user.groupAdmin === 1;
   }
 
-  log(name: string) {
-    console.log(name);
-  }
-
-  ngOnDestroy(): void {
-    this.userSubscription?.unsubscribe();
-  }
 }

--- a/src/src/app/components/layout/layout.component.html
+++ b/src/src/app/components/layout/layout.component.html
@@ -1,1 +1,2 @@
 <app-header></app-header>
+<router-outlet></router-outlet>

--- a/src/src/app/components/login/login.component.css
+++ b/src/src/app/components/login/login.component.css
@@ -4,10 +4,6 @@
     box-shadow: 0 0 5px red;
 }
 
-.group-admin-text {
-    font-size: 1.5rem;
-}
-
-.group-admin-text-color {
-    color: #d49100;
+.mat-form-field {
+    width: 100%;
 }

--- a/src/src/app/components/login/login.component.html
+++ b/src/src/app/components/login/login.component.html
@@ -2,18 +2,24 @@
     <div class="d-flex justify-content-center">
         <div class="card shadow w-50 align-items-center">
             <div class="card-body w-75">
-                <h3 class="card-title">CAEBO Secure Login</h3>
+                <div class="d-flex justify-content-center">
+                    <div>
+                        <h3 class="card-title">CAEBO Secure Login</h3>
+                    </div>
+                </div>
                 <hr>
                 <form [formGroup]='loginForm' (ngSubmit)="onSubmit()">
-                    <label for="email" class="form-label">Email Address</label>
-                    <input
-                        id="email"
-                        type="email"
-                        class="form-control"
-                        [ngClass]="{ 'focus-invalid' : f.email?.invalid && (f.email?.dirty || f.email?.touched) }"
-                        formControlName="email"
-                        placeholder="example@company.com"
-                        autofocus>
+                    <mat-form-field appearance="standard" [color]="'accent'">
+                        <mat-label>Email</mat-label>
+                        <input
+                            matInput
+                            class="mat-custom-width"
+                            id="email"
+                            type="email"
+                            formControlName="email"
+                            placeholder="example@company.com"
+                            >
+                    </mat-form-field>
                     <div *ngIf="loginForm.invalid && (loginForm.dirty || loginForm.touched)" class="text-danger">
                         <div *ngIf="f.email.errors?.required">
                             Please enter an email address.
@@ -22,19 +28,21 @@
                             Please enter a valid email address.
                         </div>
                     </div>
+                    
+                    <mat-form-field appearance="standard" [color]="'accent'">
+                        <mat-label>Password</mat-label>
+                        <input
+                            matInput
+                            id="password"
+                            type="password"
+                            formControlName="password"
+                            placeholder="xxxxxxxxxxxx"
+                            >
+                    </mat-form-field>
                     <br>
-                    <label for="pass" class="form-label">Password</label>
-                    <input 
-                        id="password"
-                        type="password"
-                        class="form-control"
-                        [ngClass]="{ 'focus-invalid' : f.password?.invalid && (f.password?.dirty || f.password?.touched) }"
-                        formControlName="password"
-                        placeholder="xxxxxxxxxxxx">
-                    <br>
-                    <button class="btn btn-primary" type="submit" [disabled]="submitting || loginForm.invalid">
+                    <button mat-raised-button color="accent" type="submit" [disabled]="submitting || loginForm.invalid">
                         <span *ngIf="!submitting">{{ submitting ? 'Logging in' : 'Log in' }}</span>
-                        <mat-spinner *ngIf="submitting" aria-label="submitting" color="accent" [diameter]="30"></mat-spinner>
+                        <mat-spinner *ngIf="submitting" aria-label="submitting" color="primary" [diameter]="30"></mat-spinner>
                     </button>
                 </form>
                 <div class="d-flex justify-content-center">
@@ -42,23 +50,6 @@
                     <span *ngIf="successMessage" class="text-success">{{ successMessage }}</span>
                 </div>
             </div>
-        </div>
-    </div>
-
-    <div *ngIf="userData" class="d-flex justify-content-center p-4">
-        <div class="card shadow w-50 d-flex align-items-center">
-                <div class="p-2">
-                    <h3>{{ userData.lastName }}, {{ userData.firstName }}</h3>
-                </div>
-                <div *ngIf="!userGroupAdmin" class="p-2">
-                    <h4><em>{{ userData.groupName }}</em></h4>
-                </div>
-                <div *ngIf="userGroupAdmin" class="p-2">
-                    <span class="group-admin-text"><em>{{ userData.groupName }} - </em><span class="group-admin-text group-admin-text-color">Admin</span></span>
-                </div>
-                <div class="p-2">
-                    <span>"{{ userData.username }}"</span>
-                </div>
         </div>
     </div>
 </div>

--- a/src/src/app/components/login/login.component.ts
+++ b/src/src/app/components/login/login.component.ts
@@ -1,8 +1,9 @@
 import { Component, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { AuthService } from 'src/app/services/auth/auth.service';
-import jwt_decode from 'jwt-decode';
 import { AuthRequest, User } from 'src/app/models/caebo.constants';
+import { SessionService } from 'src/app/services/auth/session.service';
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'app-login',
@@ -21,7 +22,10 @@ export class LoginComponent implements OnInit {
 
   constructor(
     private formBuilder: FormBuilder,
-    private authService: AuthService
+    private authService: AuthService,
+    private session: SessionService,
+    private router: Router
+
   ) { 
     this.loginForm = this.formBuilder.group({
       email: ['', [Validators.required, Validators.email]],
@@ -51,9 +55,7 @@ export class LoginComponent implements OnInit {
         if(data.statusCode !== 0) {
           this.message = 'Invalid email or password.';
         } else {
-          this.userData = this.getDecodedAccessToken(data.message?.token);
-          this.userGroupAdmin = this.userData.groupAdmin === 1;
-          this.successMessage = 'Successful Authentication.';
+          this.router.navigate(['/home']);
         }
       },
       (error) => {
@@ -63,16 +65,6 @@ export class LoginComponent implements OnInit {
       () => { this.submitting = false; }
     )
   }
-
-  getDecodedAccessToken(token: string): any {
-    try {
-      return jwt_decode(token);
-    }
-    catch(error) {
-      return null;
-    }
-  }
-
 
   clearMessages() {
     this.message = '';

--- a/src/src/app/services/auth/auth.service.ts
+++ b/src/src/app/services/auth/auth.service.ts
@@ -1,18 +1,41 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
+import { tap } from 'rxjs/operators';
+import jwt_decode from 'jwt-decode';
 import { ApiResponse, AuthRequest, AuthResponse } from 'src/app/models/caebo.constants';
 import { API } from 'src/shared/api/api.constants';
+import { SessionService } from './session.service';
 
 @Injectable({
   providedIn: 'root'
 })
 export class AuthService {
 
-  constructor(private http:HttpClient) { }
+  constructor(
+    private http:HttpClient,
+    private session: SessionService
+    ) { }
 
   login(credentials: AuthRequest): Observable<ApiResponse<AuthResponse>> {
     const url = `//localhost:5000${API.LOGIN}`;
-    return this.http.post<ApiResponse<AuthResponse>>(url, credentials);
+    return this.http.post<ApiResponse<AuthResponse>>(url, credentials)
+    .pipe(
+      tap(user => {
+        const userData = this.getDecodedAccessToken(user.message?.token)
+        if (userData) {
+          this.session.setUserSession(userData);
+        }
+      })
+    );
+  }
+
+  getDecodedAccessToken(token: string): any {
+    try {
+      return jwt_decode(token);
+    }
+    catch(error) {
+      return null;
+    }
   }
 }

--- a/src/src/app/services/auth/session-storage.service.spec.ts
+++ b/src/src/app/services/auth/session-storage.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { SessionStorageService } from './session-storage.service';
+
+describe('SessionStorageService', () => {
+  let service: SessionStorageService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(SessionStorageService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/src/app/services/auth/session-storage.service.ts
+++ b/src/src/app/services/auth/session-storage.service.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class SessionStorageService {
+
+  constructor() { }
+
+  set(key: string, value:string) {
+    window.sessionStorage.setItem(key, value);
+  }
+
+  get(key: string): string {
+    return window.sessionStorage.getItem(key);
+  }
+
+  clear() {
+    window.sessionStorage.clear();
+  }
+}

--- a/src/src/app/services/auth/session.service.spec.ts
+++ b/src/src/app/services/auth/session.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { SessionService } from './session.service';
+
+describe('SessionService', () => {
+  let service: SessionService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(SessionService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/src/app/services/auth/session.service.ts
+++ b/src/src/app/services/auth/session.service.ts
@@ -1,0 +1,33 @@
+import { Injectable } from '@angular/core';
+import { of } from 'rxjs';
+import { SessionStorageService } from './session-storage.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class SessionService {
+
+  constructor(
+    private sessionStorage: SessionStorageService
+  ) { }
+
+  setUserSession(user: any) {
+    this.sessionStorage.set("user", JSON.stringify(user));
+  }
+
+  logout() {
+    this.sessionStorage.clear();
+  }
+
+  getSessionValueAsObservable() {
+    return of({ user: JSON.parse(this.sessionStorage.get("user")) })
+  }
+
+  getSessionValue() {
+    let store = {
+      user: JSON.parse(this.sessionStorage.get("user"))
+    }
+
+    return store;
+  }
+}

--- a/src/src/app/services/user/user.service.ts
+++ b/src/src/app/services/user/user.service.ts
@@ -1,7 +1,8 @@
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { ApiResponse, User } from '../../models/caebo.constants';
+import { API } from 'src/shared/api/api.constants';
 
 @Injectable({
   providedIn: 'root'
@@ -13,6 +14,12 @@ export class UserService {
   ) { }
 
   getUsers(): Observable<ApiResponse<User[]>> {
-    return this.http.get<ApiResponse<User[]>>("//localhost:5000/api/users");
+    const url = `//localhost:5000${API.GET_USERS}`;
+    return this.http.get<ApiResponse<User[]>>(url);
+  }
+
+  getUser(id: number): Observable<ApiResponse<User>> {
+    const url = `//localhost:5000${API.GET_USER}/${id}`;
+    return this.http.get<ApiResponse<User>>(url);
   }
 }

--- a/src/src/shared/api/api.constants.ts
+++ b/src/src/shared/api/api.constants.ts
@@ -1,3 +1,5 @@
 export const API = {
-    LOGIN: '/api/users/login'
+    LOGIN: '/api/users/login',
+    GET_USERS: '/api/users',
+    GET_USER: '/api/users'
 }


### PR DESCRIPTION
Create a basic authentication system using newly created session services and material UI. Mocked up a main layout page, updated routing so we only need to add child routes to the layout component route. Implemented a basic header using material UI (subject to change) and create a simple example card on how to pull and use session data. We can use what's currently in place to add more session objects as well.